### PR TITLE
Update freedesktop platform from 22.08 to 23.08

### DIFF
--- a/io.vikunja.Vikunja.yml
+++ b/io.vikunja.Vikunja.yml
@@ -1,13 +1,14 @@
 app-id: io.vikunja.Vikunja
 
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18
+  #- org.freedesktop.Sdk.Extension.typescript
 
 build-options:
   append-path: /usr/lib/sdk/node18/bin

--- a/io.vikunja.Vikunja.yml
+++ b/io.vikunja.Vikunja.yml
@@ -8,7 +8,6 @@ runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18
-  #- org.freedesktop.Sdk.Extension.typescript
 
 build-options:
   append-path: /usr/lib/sdk/node18/bin


### PR DESCRIPTION
Solves the following error:
> org.freedesktop.Platform 22.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.