### PR TITLE
chore: Update bug tracker URL

### DIFF
--- a/io.vikunja.Vikunja.appdata.xml
+++ b/io.vikunja.Vikunja.appdata.xml
@@ -36,7 +36,7 @@
 	<launchable type="desktop-id">io.vikunja.Vikunja.desktop</launchable>
 	<content_rating type="oars-1.1" />
 	<url type="homepage">https://vikunja.io</url>
-	<url type="bugtracker">https://kolaente.dev/vikunja/vikunja/issues</url>
+	<url type="bugtracker">https://github.com/go-vikunja/vikunja/issues</url>
 	<url type="help">https://community.vikunja.io</url>
 	<releases>
 		<release version="0.24.3" date="2024-09-20" />


### PR DESCRIPTION
Update the bugtracker URL to reflect the [move to GitHub](https://vikunja.io/changelog/moving-to-github/).