### PR TITLE
Update FreeDesktop runtime from 23.08 to 24.08 and node from 18 to 20

### DIFF
--- a/io.vikunja.Vikunja.yml
+++ b/io.vikunja.Vikunja.yml
@@ -1,16 +1,16 @@
 app-id: io.vikunja.Vikunja
 
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node18
+  - org.freedesktop.Sdk.Extension.node20
 
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node20/bin
 command: vikunja
 
 finish-args:


### PR DESCRIPTION
[FreeDesktop 23.08 runtime is EOL](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/wikis/Releases) resulting in 

<img width="570" height="91" alt="image" src="https://github.com/user-attachments/assets/f752feef-bc3c-4cc1-bb0c-d9c45163ed37" />

Updated runtime and node version.