### PR TITLE
fix: add vcs-browser URL to appdata

### DIFF
--- a/io.vikunja.Vikunja.appdata.xml
+++ b/io.vikunja.Vikunja.appdata.xml
@@ -38,6 +38,7 @@
 	<url type="homepage">https://vikunja.io</url>
 	<url type="bugtracker">https://github.com/go-vikunja/vikunja/issues</url>
 	<url type="help">https://community.vikunja.io</url>
+	<url type="vcs-browser">https://github.com/go-vikunja/vikunja</url>
 	<releases>
 		<release version="2.2.2" date="2026-03-23" />
 		<release version="2.2.0" date="2026-03-20" />


### PR DESCRIPTION
Resolves the `appstream-missing-vcs-browser-url` linter warning by adding a `<url type="vcs-browser">` entry pointing to the source repository.

Fixes https://github.com/flathub/io.vikunja.Vikunja/pull/43#issuecomment-2747068041